### PR TITLE
fix: accidental inversion of the permissions in signup cog menu

### DIFF
--- a/src/events/buttons/signupButtons.ts
+++ b/src/events/buttons/signupButtons.ts
@@ -102,7 +102,7 @@ export default new CustomButtonBuilder('button-category')
 		} else if (cache == 'settings') {
 			const isAdmin = member.permissions.has('Administrator');
 			const isHost = signup.hosts.map((v) => v.user.discordId).includes(i.user.id);
-			if (isAdmin || isHost) return i.editReply({ content: 'You do not have permission to edit this signup' });
+			if (!(isAdmin || isHost)) return i.editReply({ content: 'You do not have permission to edit this signup' });
 
 			const embed = genSignupSettingsEmbed(signup);
 			const row = genSignupSettingsComponents(signup);


### PR DESCRIPTION
The permission for seeing signup settings was supposed to be restricted to hosts and admins. But I forgot to invert the check so it disallowed them but allowed everybody else.

This has now been fixed