### PR TITLE
show role icons + signup sorting

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model SignupUserJunction {
   user             User           @relation(fields: [userId], references: [id])
   userId           Int
   isTurboHost      Boolean        @default(false)
+  joinedAt         DateTime       @default(now())
 }
 
 // Vote Counter

--- a/src/views/roles.ts
+++ b/src/views/roles.ts
@@ -8,6 +8,7 @@ export function genRoleEmbed(role: Role) {
 
 	if (role.flavourText) embed.setDescription(`*${role.flavourText}*`);
 	if (role.wikiUrl) embed.setURL(role.wikiUrl);
+	if (role.iconUrl) embed.setThumbnail(role.iconUrl);
 	if (role.isRetired)
 		embed.setFooter({
 			text: 'This role is retired',

--- a/src/views/signups.ts
+++ b/src/views/signups.ts
@@ -57,9 +57,9 @@ export function formatSignupEmbed(signup: FullSignup) {
 		const { name, isLocked, limit } = category;
 		const userIds = category.users
 			.sort((a, b) => (a.isTurboHost && !b.isTurboHost ? -1 : 1))
+			.sort((a, b) => (a.joinedAt > b.joinedAt ? -1 : 1))
 			.map((user, index) => {
 				totalUsers.push(user.user.discordId);
-
 				let categoryName = name;
 				if (categoryName.endsWith('s')) categoryName = categoryName.slice(0, -1);
 


### PR DESCRIPTION
- Signup categories are explicitly sorted by join time
- Rolecards using `/view role` or similar command now show the appropriate role icon if one is supplied