### PR TITLE
fix: disallow stickers from external servers

### DIFF
--- a/src/events/discordEvents/onMessageCreate.ts
+++ b/src/events/discordEvents/onMessageCreate.ts
@@ -1,4 +1,4 @@
-import { ChannelType, Message, Webhook } from 'discord.js';
+import { ChannelType, Message, Sticker, Webhook } from 'discord.js';
 import { client } from '../../controllers/botController';
 import { getAnonymousGroup, getAnonymousProfiles } from '../../models/anonymity';
 
@@ -32,7 +32,15 @@ export default async function OnMessageCreate(msg: Message<boolean>) {
 		webhook = newWH;
 	}
 
-	const stickerURLs = msg.stickers.map((sticker) => {
+	const stickers: Sticker[] = [];
+	for (const stickerData of msg.stickers) {
+		const sticker = stickerData[1];
+		const fetchedSticker = await sticker.fetch();
+		if (fetchedSticker.guildId == msg.guildId) stickers.push(fetchedSticker);
+		else console.log(fetchedSticker);
+	}
+
+	const stickerURLs = stickers.map((sticker) => {
 		const url = `https://media.discordapp.net/stickers/${sticker.id}.gif?size=2048`;
 		return url;
 	});


### PR DESCRIPTION
Stickers fail to be accessed when they're on external servers, so this catches that to not send a useless URL