### PR TITLE
Reimplemented cog menu for managing signups

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
 	rules: {
 		indent: ['error', 'tab', { SwitchCase: 1 }],
 		'linebreak-style': ['error', 'unix'],
-		quotes: ['error', 'single'],
+		quotes: ['error', 'single', { avoidEscape: true }],
 		semi: ['error', 'always'],
 		'@typescript-eslint/no-unused-vars': [
 			'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,11 @@ module.exports = {
 		es2021: true,
 		node: true,
 	},
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'prettier',
+	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
 		ecmaVersion: 'latest',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Basic database tables for discord servers and users.
 -   Project rewrite starter
 
-[Unreleased]: https://github.com/JacksonVirgo/ms-modtools
+[Unreleased]: https://github.com/JacksonVirgo/mafia-engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Manage signups (for hosts) via buttons and interactions
+    -   Creating categories
+    -   Deleting categories
+    -   Updating categories
+        -   Rename
+        -   Change limit
+        -   Add users
+        -   Remove users
+        -   Cull users that left the server (as they cannot be fetched via a user select menu)
+    -   Toggle anonymity
+    -   Change name of signups
+-   Signup logging using webhooks
+
+## [0.1.0]
+
 ### Added
 
 -   Added button menu for interacting with signup settings
@@ -16,3 +31,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Project rewrite starter
 
 [Unreleased]: https://github.com/JacksonVirgo/mafia-engine
+[0.1.0]: https://github.com/discord-mafia/mafia-engine/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Added button menu for interacting with signup settings
 -   Anonymity feature for signups
 -   Basic signups via commands
 -   Basic database tables for discord servers and users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+-   Anonymity feature for signups
+-   Basic signups via commands
+-   Basic database tables for discord servers and users.
+-   Project rewrite starter
+
+[Unreleased]: https://github.com/JacksonVirgo/ms-modtools

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Mafia Engine is a Discord bot written in Typescript. It is designed to be a simp
 
 This bot is currently in development and is actively getting new features and bug fixes. If you have any suggestions or find any bugs, please feel free to open an issue or pull request.
 
+You can access the projects changelog [here](CHANGELOG.md). This will cover the project starting from the rewrite.
+
 ## Bot Features
 
 -   Signup / Looking For Group functionality
@@ -23,7 +25,7 @@ This bot is currently in development and is actively getting new features and bu
 
 1. Clone the repository in a directory of your choice
 2. Run `npm install` to install all dependencies
-3. Rename `.env.example` to `.env` and fill in the appropriate values
+3. Copy `.env.example` into a new file `.env` and fill in the appropriate values
 
 **To run the bot officially**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@typescript-eslint/parser": "^6.4.1",
 				"drizzle-kit": "^0.24.0",
 				"eslint": "^8.48.0",
+				"eslint-config-prettier": "^9.1.0",
 				"ts-node": "^10.9.1"
 			}
 		},
@@ -2041,6 +2042,18 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+			"dev": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@typescript-eslint/parser": "^6.4.1",
 		"drizzle-kit": "^0.24.0",
 		"eslint": "^8.48.0",
+		"eslint-config-prettier": "^9.1.0",
 		"ts-node": "^10.9.1"
 	},
 	"nodemonConfig": {

--- a/src/builders/button.ts
+++ b/src/builders/button.ts
@@ -5,8 +5,8 @@ import {
 	ButtonStyle,
 	ComponentEmojiResolvable,
 } from 'discord.js';
-import { verifyCustomId } from '../utils/customId';
 import { handleInteractionError } from '../utils/errors';
+import { CustomId } from '../utils/customId';
 
 export type ButtonContext = string | undefined;
 
@@ -27,15 +27,18 @@ export class Button {
 	private builder: ButtonBuilder;
 	private executeFunction: ButtonExecute = defaultButtonExecute;
 
+	private staticCustomId: string;
+
 	constructor(custom_id: string) {
 		if (Button.buttons.has(custom_id))
 			throw new Error(`Button ${custom_id} already exists.`);
 
-		if (!verifyCustomId(custom_id))
+		if (!CustomId.verifyRaw(custom_id))
 			throw new Error(
 				`Button ${custom_id} is not in the correct format.`
 			);
 
+		this.staticCustomId = custom_id;
 		this.builder = new ButtonBuilder().setCustomId(custom_id);
 		Button.buttons.set(custom_id, this);
 	}
@@ -78,10 +81,19 @@ export class Button {
 		return this;
 	}
 
+	public getCustomId() {
+		return this.staticCustomId;
+	}
+
 	public build(customId?: string) {
 		const newBuilder = this.builder;
 		if (customId) newBuilder.setCustomId(customId);
 		return newBuilder;
+	}
+
+	public buildWithContext(ctx: string) {
+		const newCustomId = new CustomId(this.getCustomId(), ctx);
+		return this.build(newCustomId.getHydrated());
 	}
 
 	public buildAsRow(customId?: string) {

--- a/src/builders/button.ts
+++ b/src/builders/button.ts
@@ -6,7 +6,7 @@ import {
 	ComponentEmojiResolvable,
 } from 'discord.js';
 import { verifyCustomId } from '../utils/customId';
-import { handleInteractionError, InteractionError } from '../utils/errors';
+import { handleInteractionError } from '../utils/errors';
 
 export type ButtonContext = string | undefined;
 

--- a/src/builders/modal.ts
+++ b/src/builders/modal.ts
@@ -1,0 +1,45 @@
+import { ModalBuilder, ModalSubmitInteraction } from 'discord.js';
+import { verifyCustomId } from '../utils/customId';
+import { handleInteractionError } from '../utils/errors';
+
+export type ModalContext = string | undefined;
+
+export type ModalExecute = (
+	i: ModalSubmitInteraction,
+	ctx: ModalContext
+) => unknown | Promise<unknown>;
+
+const defaultModalExecute: ModalExecute = async (i, _ctx) => {
+	await i.reply({
+		content: 'This modal has not been implemented yet.',
+		ephemeral: true,
+	});
+};
+
+export class Modal extends ModalBuilder {
+	public static modals = new Map<string, Modal>();
+	private executeFunction: ModalExecute = defaultModalExecute;
+
+	constructor(custom_id: string) {
+		super();
+		if (Modal.modals.has(custom_id))
+			throw new Error(`Modal ${custom_id} already exists.`);
+		if (!verifyCustomId(custom_id))
+			throw new Error(`Modal ${custom_id} is not in the correct format.`);
+		this.setCustomId(custom_id);
+		Modal.modals.set(custom_id, this);
+	}
+
+	public onExecute(executeFunction: ModalExecute) {
+		this.executeFunction = executeFunction;
+		return this;
+	}
+
+	public async run(inter: ModalSubmitInteraction, ctx?: string) {
+		try {
+			await this.executeFunction(inter, ctx);
+		} catch (err) {
+			await handleInteractionError(err, inter);
+		}
+	}
+}

--- a/src/builders/modal.ts
+++ b/src/builders/modal.ts
@@ -1,12 +1,15 @@
-import { ModalBuilder, ModalSubmitInteraction } from 'discord.js';
-import { verifyCustomId } from '../utils/customId';
+import {
+	ActionRowBuilder,
+	ModalBuilder,
+	ModalSubmitInteraction,
+} from 'discord.js';
 import { handleInteractionError } from '../utils/errors';
-
-export type ModalContext = string | undefined;
+import { TextInputBuilder } from '@discordjs/builders';
+import { CustomId } from '../utils/customId';
 
 export type ModalExecute = (
 	i: ModalSubmitInteraction,
-	ctx: ModalContext
+	ctx?: string
 ) => unknown | Promise<unknown>;
 
 const defaultModalExecute: ModalExecute = async (i, _ctx) => {
@@ -19,12 +22,15 @@ const defaultModalExecute: ModalExecute = async (i, _ctx) => {
 export class Modal extends ModalBuilder {
 	public static modals = new Map<string, Modal>();
 	private executeFunction: ModalExecute = defaultModalExecute;
+	public customId: string;
+	private inputs: TextInputBuilder[] = [];
 
 	constructor(custom_id: string) {
 		super();
+		this.customId = custom_id;
 		if (Modal.modals.has(custom_id))
 			throw new Error(`Modal ${custom_id} already exists.`);
-		if (!verifyCustomId(custom_id))
+		if (!CustomId.verifyRaw(custom_id))
 			throw new Error(`Modal ${custom_id} is not in the correct format.`);
 		this.setCustomId(custom_id);
 		Modal.modals.set(custom_id, this);
@@ -35,11 +41,30 @@ export class Modal extends ModalBuilder {
 		return this;
 	}
 
+	public set(...inputs: TextInputBuilder[]) {
+		this.addComponents(
+			new ActionRowBuilder<TextInputBuilder>().addComponents(...inputs)
+		);
+		this.inputs = inputs;
+		return this;
+	}
+
 	public async run(inter: ModalSubmitInteraction, ctx?: string) {
 		try {
 			await this.executeFunction(inter, ctx);
 		} catch (err) {
 			await handleInteractionError(err, inter);
 		}
+	}
+
+	public build(customId?: string) {
+		const modal = new ModalBuilder(this.data);
+		const rows: ActionRowBuilder<TextInputBuilder>[] = this.inputs.map(
+			(input) =>
+				new ActionRowBuilder<TextInputBuilder>().addComponents(input)
+		);
+		modal.setComponents(rows);
+		if (customId) modal.setCustomId(customId);
+		return modal;
 	}
 }

--- a/src/builders/textSelectMenu.ts
+++ b/src/builders/textSelectMenu.ts
@@ -2,8 +2,8 @@ import {
 	StringSelectMenuBuilder,
 	StringSelectMenuInteraction,
 } from 'discord.js';
-import { verifyCustomId } from '../utils/customId';
 import { handleInteractionError } from '../utils/errors';
+import { CustomId } from '../utils/customId';
 
 export type TextSelectMenuContext = string | undefined;
 
@@ -29,7 +29,7 @@ export class TextSelectMenu extends StringSelectMenuBuilder {
 		if (TextSelectMenu.textSelectMenus.has(custom_id))
 			throw new Error(`Text select menu ${custom_id} already exists.`);
 
-		if (!verifyCustomId(custom_id))
+		if (!CustomId.verifyRaw(custom_id))
 			throw new Error(
 				`Text select menu ${custom_id} is not in the correct format.`
 			);

--- a/src/builders/textSelectMenu.ts
+++ b/src/builders/textSelectMenu.ts
@@ -23,6 +23,7 @@ export class TextSelectMenu extends StringSelectMenuBuilder {
 	public static textSelectMenus = new Map<string, TextSelectMenu>();
 	private executeFunction: TextSelectMenuExecute =
 		defaultTextSelectMenuExecute;
+	private staticCustomId: string;
 
 	constructor(custom_id: string) {
 		super();
@@ -35,6 +36,7 @@ export class TextSelectMenu extends StringSelectMenuBuilder {
 			);
 
 		this.setCustomId(custom_id);
+		this.staticCustomId = custom_id;
 		TextSelectMenu.textSelectMenus.set(custom_id, this);
 	}
 
@@ -49,6 +51,10 @@ export class TextSelectMenu extends StringSelectMenuBuilder {
 		} catch (err) {
 			await handleInteractionError(err, inter);
 		}
+	}
+
+	public getCustomId() {
+		return this.staticCustomId;
 	}
 
 	public build(customId?: string) {

--- a/src/builders/textSelectMenu.ts
+++ b/src/builders/textSelectMenu.ts
@@ -1,0 +1,53 @@
+import {
+	StringSelectMenuBuilder,
+	StringSelectMenuInteraction,
+} from 'discord.js';
+import { verifyCustomId } from '../utils/customId';
+import { handleInteractionError } from '../utils/errors';
+
+export type TextSelectMenuContext = string | undefined;
+
+export type TextSelectMenuExecute = (
+	i: StringSelectMenuInteraction,
+	ctx: TextSelectMenuContext
+) => unknown | Promise<unknown>;
+
+const defaultTextSelectMenuExecute: TextSelectMenuExecute = async (i, _ctx) => {
+	await i.reply({
+		content: 'This text select menu has not been implemented yet.',
+		ephemeral: true,
+	});
+};
+
+export class TextSelectMenu extends StringSelectMenuBuilder {
+	public static textSelectMenus = new Map<string, TextSelectMenu>();
+	private executeFunction: TextSelectMenuExecute =
+		defaultTextSelectMenuExecute;
+
+	constructor(custom_id: string) {
+		super();
+		if (TextSelectMenu.textSelectMenus.has(custom_id))
+			throw new Error(`Text select menu ${custom_id} already exists.`);
+
+		if (!verifyCustomId(custom_id))
+			throw new Error(
+				`Text select menu ${custom_id} is not in the correct format.`
+			);
+
+		this.setCustomId(custom_id);
+		TextSelectMenu.textSelectMenus.set(custom_id, this);
+	}
+
+	public onExecute(executeFunction: TextSelectMenuExecute) {
+		this.executeFunction = executeFunction;
+		return this;
+	}
+
+	public async run(inter: StringSelectMenuInteraction, ctx?: string) {
+		try {
+			await this.executeFunction(inter, ctx);
+		} catch (err) {
+			await handleInteractionError(err, inter);
+		}
+	}
+}

--- a/src/builders/textSelectMenu.ts
+++ b/src/builders/textSelectMenu.ts
@@ -50,4 +50,10 @@ export class TextSelectMenu extends StringSelectMenuBuilder {
 			await handleInteractionError(err, inter);
 		}
 	}
+
+	public build(customId?: string) {
+		const newBuilder = new StringSelectMenuBuilder(this.data);
+		if (customId) newBuilder.setCustomId(customId);
+		return newBuilder;
+	}
 }

--- a/src/builders/userSelectMenu.ts
+++ b/src/builders/userSelectMenu.ts
@@ -20,7 +20,7 @@ export class UserSelectMenu extends UserSelectMenuBuilder {
 	public static selectMenus = new Map<string, UserSelectMenu>();
 	private executeFunction: UserSelectMenuExecute =
 		defaultTextSelectMenuExecute;
-
+	private staticCustomId: string;
 	constructor(custom_id: string) {
 		super();
 		if (UserSelectMenu.selectMenus.has(custom_id))
@@ -32,6 +32,7 @@ export class UserSelectMenu extends UserSelectMenuBuilder {
 			);
 
 		this.setCustomId(custom_id);
+		this.staticCustomId = custom_id;
 		UserSelectMenu.selectMenus.set(custom_id, this);
 	}
 
@@ -46,6 +47,10 @@ export class UserSelectMenu extends UserSelectMenuBuilder {
 		} catch (err) {
 			await handleInteractionError(err, inter);
 		}
+	}
+
+	public getCustomId() {
+		return this.staticCustomId;
 	}
 
 	public build(customId?: string) {

--- a/src/builders/userSelectMenu.ts
+++ b/src/builders/userSelectMenu.ts
@@ -1,0 +1,56 @@
+import { UserSelectMenuBuilder, UserSelectMenuInteraction } from 'discord.js';
+import { handleInteractionError } from '../utils/errors';
+import { CustomId } from '../utils/customId';
+
+export type TextSelectMenuContext = string | undefined;
+
+export type UserSelectMenuExecute = (
+	i: UserSelectMenuInteraction,
+	ctx: TextSelectMenuContext
+) => unknown | Promise<unknown>;
+
+const defaultTextSelectMenuExecute: UserSelectMenuExecute = async (i, _ctx) => {
+	await i.reply({
+		content: 'This user select menu has not been implemented yet.',
+		ephemeral: true,
+	});
+};
+
+export class UserSelectMenu extends UserSelectMenuBuilder {
+	public static selectMenus = new Map<string, UserSelectMenu>();
+	private executeFunction: UserSelectMenuExecute =
+		defaultTextSelectMenuExecute;
+
+	constructor(custom_id: string) {
+		super();
+		if (UserSelectMenu.selectMenus.has(custom_id))
+			throw new Error(`User select menu ${custom_id} already exists.`);
+
+		if (!CustomId.verifyRaw(custom_id))
+			throw new Error(
+				`User select menu ${custom_id} is not in the correct format.`
+			);
+
+		this.setCustomId(custom_id);
+		UserSelectMenu.selectMenus.set(custom_id, this);
+	}
+
+	public onExecute(executeFunction: UserSelectMenuExecute) {
+		this.executeFunction = executeFunction;
+		return this;
+	}
+
+	public async run(inter: UserSelectMenuInteraction, ctx?: string) {
+		try {
+			await this.executeFunction(inter, ctx);
+		} catch (err) {
+			await handleInteractionError(err, inter);
+		}
+	}
+
+	public build(customId?: string) {
+		const newBuilder = new UserSelectMenuBuilder(this.data);
+		if (customId) newBuilder.setCustomId(customId);
+		return newBuilder;
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ const envSchema = z.object({
 	DATABASE_URL: z.string(),
 	DISCORD_TOKEN: z.string(),
 	DISCORD_CLIENT_ID: z.string(),
+
+	TMP_SIGNUP_LOG_WEBHOOK: z.string().optional(),
 });
 
 export function fetchConfig() {

--- a/src/db/signups.ts
+++ b/src/db/signups.ts
@@ -131,6 +131,7 @@ export type HydratedCategory = SignupCategory & {
 
 export type HydratedUser = User & {
 	username?: string;
+	createdAt: Date;
 };
 
 export async function getHydratedSignupFromChannel(channelId: string) {
@@ -153,11 +154,13 @@ export async function getHydratedSignup(
 	const messageId = 'messageId' in query ? query.messageId : null;
 	const signupId = 'signupId' in query ? query.signupId : null;
 
+	//prettier-ignore
 	const whereClause = signupId
 		? eq(signups.id, signupId)
 		: messageId
-		? eq(signups.messageId, messageId)
-		: null;
+			? eq(signups.messageId, messageId)
+			: null;
+
 	if (!whereClause) return null;
 
 	const signup =
@@ -182,7 +185,11 @@ export async function getHydratedSignup(
 		for (const signup_user of signup_users) {
 			const usr = await getUser(signup_user.userId);
 			if (!usr) continue;
-			true_users.push({ ...usr, username: usr.username });
+			true_users.push({
+				...usr,
+				username: usr.username,
+				createdAt: signup_user.createdAt,
+			});
 		}
 
 		const cat: HydratedCategory = {
@@ -216,7 +223,11 @@ export async function getHydratedCategory(
 	for (const signup_user of signup_users) {
 		const usr = await getUser(signup_user.userId);
 		if (!usr) continue;
-		true_users.push({ ...usr, username: usr.username });
+		true_users.push({
+			...usr,
+			username: usr.username,
+			createdAt: signup_user.createdAt,
+		});
 	}
 
 	const hydrated: HydratedCategory = {

--- a/src/db/signups.ts
+++ b/src/db/signups.ts
@@ -202,6 +202,14 @@ export async function getHydratedSignup(
 	return { ...signup, categories: true_categories };
 }
 
+export async function deleteCategory(categoryId: number) {
+	const res = await db
+		.delete(signupCategories)
+		.where(eq(signupCategories.id, categoryId))
+		.returning();
+	return res.shift() ?? null;
+}
+
 export async function getHydratedCategory(
 	categoryId: number
 ): Promise<HydratedCategory | null> {

--- a/src/db/signups.ts
+++ b/src/db/signups.ts
@@ -187,6 +187,38 @@ export async function getHydratedSignup(
 	return { ...signup, categories: true_categories };
 }
 
+export async function getHydratedCategory(
+	categoryId: number
+): Promise<HydratedCategory | null> {
+	const res = await db
+		.select()
+		.from(signupCategories)
+		.where(eq(signupCategories.id, categoryId))
+		.limit(1);
+
+	const category = res.shift();
+	if (!category) return null;
+
+	const signup_users = await db
+		.select()
+		.from(signupUsers)
+		.where(eq(signupUsers.categoryId, category.id));
+
+	const true_users: HydratedUser[] = [];
+	for (const signup_user of signup_users) {
+		const usr = await getUser(signup_user.userId);
+		if (!usr) continue;
+		true_users.push({ ...usr, username: usr.username });
+	}
+
+	const hydrated: HydratedCategory = {
+		...category,
+		users: true_users,
+	};
+
+	return hydrated;
+}
+
 export async function addUserToCategory(query: NewSignupUser) {
 	const rawCategory = await db
 		.select()

--- a/src/db/signups.ts
+++ b/src/db/signups.ts
@@ -140,7 +140,6 @@ export async function getHydratedSignupFromChannel(channelId: string) {
 		.where(and(eq(signups.channelId, channelId)))
 		.limit(1);
 	const sign = signup.shift() ?? null;
-	console.log(sign);
 	if (!sign) return null;
 	return await getHydratedSignup(sign.messageId);
 }

--- a/src/db/signups.ts
+++ b/src/db/signups.ts
@@ -458,3 +458,12 @@ export async function deleteCategoryFromSignup(
 		.returning();
 	return category.shift() ?? null;
 }
+
+export async function updateSignupName(signupId: number, name: string) {
+	const res = await db
+		.update(signups)
+		.set({ name })
+		.where(eq(signups.id, signupId))
+		.returning();
+	return res.shift() ?? null;
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -24,6 +24,8 @@ export default async function onInteraction(i: Interaction<any>) {
 			return await handleButton(i as ButtonInteraction);
 		case i.isModalSubmit():
 			return await handleModalSubmit(i as ModalSubmitInteraction);
+		case i.isStringSelectMenu():
+			return await handleTextSelectMenu(i as StringSelectMenuInteraction);
 		default:
 			if (i.isRepliable()) {
 				await i.reply({

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -3,7 +3,6 @@ import { SlashCommand } from '../builders/slashCommand';
 import { Button } from '../builders/button';
 import { parseCustomId } from '../utils/customId';
 import { SubCommandHandler } from '../builders/subcommandHandler';
-import { handleInteractionError } from '../utils/errors';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function onInteraction(i: Interaction<any>) {

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -5,6 +5,7 @@ import type {
 	Interaction,
 	ModalSubmitInteraction,
 	StringSelectMenuInteraction,
+	UserSelectMenuInteraction,
 } from 'discord.js';
 import { SlashCommand } from '../builders/slashCommand';
 import { Button } from '../builders/button';
@@ -12,6 +13,7 @@ import { SubCommandHandler } from '../builders/subcommandHandler';
 import { Modal } from '../builders/modal';
 import { TextSelectMenu } from '../builders/textSelectMenu';
 import { CustomId } from '../utils/customId';
+import { UserSelectMenu } from '../builders/userSelectMenu';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function onInteraction(i: Interaction<any>) {
@@ -26,6 +28,8 @@ export default async function onInteraction(i: Interaction<any>) {
 			return await handleModalSubmit(i as ModalSubmitInteraction);
 		case i.isStringSelectMenu():
 			return await handleTextSelectMenu(i as StringSelectMenuInteraction);
+		case i.isUserSelectMenu():
+			return await handleUserSelectMenu(i as UserSelectMenuInteraction);
 		default:
 			if (i.isRepliable()) {
 				await i.reply({
@@ -107,4 +111,15 @@ async function handleTextSelectMenu(i: StringSelectMenuInteraction) {
 		});
 	}
 	await selectMenu.run(i, customId.getContext());
+}
+
+async function handleUserSelectMenu(i: UserSelectMenuInteraction) {
+	const customId = CustomId.parseString(i.customId);
+	const selectMenu = UserSelectMenu.selectMenus.get(customId.getId());
+	if (!selectMenu) {
+		return i.reply({
+			content: 'This select menu does not exist',
+			ephemeral: true,
+		});
+	}
 }

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -122,4 +122,5 @@ async function handleUserSelectMenu(i: UserSelectMenuInteraction) {
 			ephemeral: true,
 		});
 	}
+	await selectMenu.run(i, customId.getContext());
 }

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -4,12 +4,14 @@ import type {
 	ChatInputCommandInteraction,
 	Interaction,
 	ModalSubmitInteraction,
+	StringSelectMenuInteraction,
 } from 'discord.js';
 import { SlashCommand } from '../builders/slashCommand';
 import { Button } from '../builders/button';
 import { parseCustomId } from '../utils/customId';
 import { SubCommandHandler } from '../builders/subcommandHandler';
 import { Modal } from '../builders/modal';
+import { TextSelectMenu } from '../builders/textSelectMenu';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function onInteraction(i: Interaction<any>) {
@@ -90,5 +92,19 @@ async function handleModalSubmit(i: ModalSubmitInteraction) {
 			ephemeral: true,
 		});
 	}
-	return await modal.run(i);
+	const ctx = parseCustomId(i.customId);
+	return await modal.run(i, ctx.context);
+}
+
+async function handleTextSelectMenu(i: StringSelectMenuInteraction) {
+	const selectMenu = TextSelectMenu.textSelectMenus.get(i.customId);
+	if (!selectMenu) {
+		return i.reply({
+			content: 'This select menu does not exist',
+			ephemeral: true,
+		});
+	}
+
+	const ctx = parseCustomId(i.customId);
+	await selectMenu.run(i, ctx.context);
 }

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -8,10 +8,10 @@ import type {
 } from 'discord.js';
 import { SlashCommand } from '../builders/slashCommand';
 import { Button } from '../builders/button';
-import { parseCustomId } from '../utils/customId';
 import { SubCommandHandler } from '../builders/subcommandHandler';
 import { Modal } from '../builders/modal';
 import { TextSelectMenu } from '../builders/textSelectMenu';
+import { CustomId } from '../utils/customId';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function onInteraction(i: Interaction<any>) {
@@ -72,41 +72,39 @@ async function handleAutocomplete(i: AutocompleteInteraction) {
 }
 
 async function handleButton(i: ButtonInteraction) {
-	const parsedCustomID = parseCustomId(i.customId);
-	const button = Button.buttons.get(parsedCustomID.custom_id);
+	const customId = CustomId.parseString(i.customId);
+	const button = Button.buttons.get(customId.getId());
 	if (!button)
 		return i.reply({
 			content: 'This button does not exist',
 			ephemeral: true,
 		});
 	try {
-		const ctx = parseCustomId(i.customId);
-		await button.run(i, ctx.context);
+		await button.run(i, customId.getContext());
 	} catch (err) {
 		console.log(err);
 	}
 }
 async function handleModalSubmit(i: ModalSubmitInteraction) {
-	const modal = Modal.modals.get(i.customId);
+	const customId = CustomId.parseString(i.customId);
+	const modal = Modal.modals.get(customId.getId());
 	if (!modal) {
 		return i.reply({
 			content: 'This modal does not exist',
 			ephemeral: true,
 		});
 	}
-	const ctx = parseCustomId(i.customId);
-	return await modal.run(i, ctx.context);
+	return await modal.run(i, customId.getContext());
 }
 
 async function handleTextSelectMenu(i: StringSelectMenuInteraction) {
-	const selectMenu = TextSelectMenu.textSelectMenus.get(i.customId);
+	const customId = CustomId.parseString(i.customId);
+	const selectMenu = TextSelectMenu.textSelectMenus.get(customId.getId());
 	if (!selectMenu) {
 		return i.reply({
 			content: 'This select menu does not exist',
 			ephemeral: true,
 		});
 	}
-
-	const ctx = parseCustomId(i.customId);
-	await selectMenu.run(i, ctx.context);
+	await selectMenu.run(i, customId.getContext());
 }

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,51 +1,37 @@
-import type { ChatInputCommandInteraction, Interaction } from 'discord.js';
+import type {
+	AutocompleteInteraction,
+	ButtonInteraction,
+	ChatInputCommandInteraction,
+	Interaction,
+	ModalSubmitInteraction,
+} from 'discord.js';
 import { SlashCommand } from '../builders/slashCommand';
 import { Button } from '../builders/button';
 import { parseCustomId } from '../utils/customId';
 import { SubCommandHandler } from '../builders/subcommandHandler';
+import { Modal } from '../builders/modal';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function onInteraction(i: Interaction<any>) {
-	if (i.isChatInputCommand()) {
-		handleSlashCommand(i);
-	} else if (i.isAutocomplete()) {
-		if (i.options.getSubcommand()) {
-			const handler = SubCommandHandler.subcommandHandlers.get(
-				i.commandName
-			);
-			if (!handler)
-				return await i.respond([
-					{
-						name: 'Invalid Subcommand',
-						value: 'Invalid Subcommand',
-					},
-				]);
-
-			await handler.onAutocomplete(i);
-		}
-	} else if (i.isButton()) {
-		const parsedCustomID = parseCustomId(i.customId);
-		const button = Button.buttons.get(parsedCustomID.custom_id);
-		if (!button)
-			return i.reply({
-				content: 'This button does not exist',
-				ephemeral: true,
-			});
-		try {
-			const ctx = parseCustomId(i.customId);
-			await button.run(i, ctx.context);
-		} catch (err) {
-			console.log(err);
-		}
-	} else {
-		if (i.isRepliable()) {
-			await i.reply({
-				content: 'This interaction type is not supported yet.',
-				ephemeral: true,
-			});
-		} else {
-			console.log('Interaction type not supported yet.', i);
-		}
+	switch (true) {
+		case i.isChatInputCommand():
+			return await handleSlashCommand(i as ChatInputCommandInteraction);
+		case i.isAutocomplete():
+			return await handleAutocomplete(i as AutocompleteInteraction);
+		case i.isButton():
+			return await handleButton(i as ButtonInteraction);
+		case i.isModalSubmit():
+			return await handleModalSubmit(i as ModalSubmitInteraction);
+		default:
+			if (i.isRepliable()) {
+				await i.reply({
+					content: 'This interaction type is not supported yet.',
+					ephemeral: true,
+				});
+			} else {
+				console.log('Interaction type not supported yet.', i);
+			}
+			break;
 	}
 }
 
@@ -64,4 +50,45 @@ async function handleSlashCommand(i: ChatInputCommandInteraction) {
 		return await subcommandHandler.run(i);
 	}
 	return await slashCommand.run(i);
+}
+
+async function handleAutocomplete(i: AutocompleteInteraction) {
+	if (i.options.getSubcommand()) {
+		const handler = SubCommandHandler.subcommandHandlers.get(i.commandName);
+		if (!handler)
+			return await i.respond([
+				{
+					name: 'Invalid Subcommand',
+					value: 'Invalid Subcommand',
+				},
+			]);
+
+		await handler.onAutocomplete(i);
+	}
+}
+
+async function handleButton(i: ButtonInteraction) {
+	const parsedCustomID = parseCustomId(i.customId);
+	const button = Button.buttons.get(parsedCustomID.custom_id);
+	if (!button)
+		return i.reply({
+			content: 'This button does not exist',
+			ephemeral: true,
+		});
+	try {
+		const ctx = parseCustomId(i.customId);
+		await button.run(i, ctx.context);
+	} catch (err) {
+		console.log(err);
+	}
+}
+async function handleModalSubmit(i: ModalSubmitInteraction) {
+	const modal = Modal.modals.get(i.customId);
+	if (!modal) {
+		return i.reply({
+			content: 'This modal does not exist',
+			ephemeral: true,
+		});
+	}
+	return await modal.run(i);
 }

--- a/src/interactions/signups/buttons/categoryLeave.ts
+++ b/src/interactions/signups/buttons/categoryLeave.ts
@@ -4,6 +4,7 @@ import { getOrInsertUser } from '../../../db/users';
 import { InteractionError } from '../../../utils/errors';
 import { leaveSignups } from '../../../db/signups';
 import { onSignupUpdate } from '../signupUpdateEvent';
+import { logSignup, LogType } from '../../../utils/logging';
 
 export const leaveCategoryBtn = new Button('signup-leave')
 	.setStyle(ButtonStyle.Secondary)
@@ -22,5 +23,11 @@ export const leaveCategoryBtn = new Button('signup-leave')
 		onSignupUpdate.publish({
 			messageId: i.message.id,
 			i,
+		});
+
+		await logSignup({
+			user: user.username,
+			type: LogType.LEAVE,
+			channelId: i.message.channelId,
 		});
 	});

--- a/src/interactions/signups/buttons/settings.ts
+++ b/src/interactions/signups/buttons/settings.ts
@@ -20,7 +20,9 @@ export default new Button('signup-settings')
 			});
 		}
 
-		const signup = await getHydratedSignup(i.message.id);
+		const signup = await getHydratedSignup({
+			messageId: i.message?.id,
+		});
 		if (!signup) {
 			throw new InteractionError({
 				status: ErrorCode.NotFound,

--- a/src/interactions/signups/buttons/settings.ts
+++ b/src/interactions/signups/buttons/settings.ts
@@ -1,6 +1,8 @@
 import { ButtonStyle, PermissionFlagsBits } from 'discord.js';
 import { Button } from '../../../builders/button';
 import { ErrorCode, InteractionError } from '../../../utils/errors';
+import { getHydratedSignup } from '../../../db/signups';
+import { generalSettingsEmbed } from '../settings/general';
 
 export default new Button('signup-settings')
 	.setStyle(ButtonStyle.Secondary)
@@ -10,14 +12,27 @@ export default new Button('signup-settings')
 			PermissionFlagsBits.ManageChannels
 		);
 
-		throw new InteractionError({
-			status: ErrorCode.NotPermitted,
-			message:
-				'You need to have the "Manage Channels" permission to edit the signups',
-		});
+		if (!canManageChannels) {
+			throw new InteractionError({
+				status: ErrorCode.NotPermitted,
+				message:
+					'You need to have the "Manage Channels" permission to edit the signups',
+			});
+		}
+
+		const signup = await getHydratedSignup(i.message.id);
+		if (!signup) {
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Failed to find signup',
+			});
+		}
+
+		const { embed, row } = await generalSettingsEmbed(signup);
 
 		await i.reply({
-			content: 'This button has not been implemented yet.',
+			embeds: [embed],
+			components: row.components.length > 0 ? [row] : undefined,
 			ephemeral: true,
 		});
 	});

--- a/src/interactions/signups/create.ts
+++ b/src/interactions/signups/create.ts
@@ -74,7 +74,9 @@ export const createSignup = new SubCommand('create')
 			isHoisted: true,
 		});
 
-		const hydrated = await getHydratedSignup(deferred.id);
+		const hydrated = await getHydratedSignup({
+			messageId: deferred.id,
+		});
 		if (!hydrated) throw new InteractionError('Failed to hydrate signup');
 
 		const embed = formatSignupEmbed(hydrated);

--- a/src/interactions/signups/remove.ts
+++ b/src/interactions/signups/remove.ts
@@ -4,12 +4,10 @@ import { SubCommand } from '../../builders/subcommand';
 import { InteractionError } from '../../utils/errors';
 import {
 	getCategoryNames,
-	getHydratedSignup,
 	getSignupByChannel,
 	getUserNames,
 	removeUserFromCategory,
 } from '../../db/signups';
-import { formatSignupEmbed, formatSignupComponents } from '../../views/signup';
 import { getUserByName } from '../../db/users';
 import { trigramSimilarity } from '../../utils/string';
 import { onSignupUpdate } from './signupUpdateEvent';

--- a/src/interactions/signups/settings/categories.ts
+++ b/src/interactions/signups/settings/categories.ts
@@ -6,7 +6,7 @@ import {
 } from 'discord.js';
 import { Button } from '../../../builders/button';
 import { HydratedSignup } from '../../../db/signups';
-import { manageCategories, miscSettings, signupSettingsHome } from './general';
+import { signupSettingsHome } from './general';
 
 export const editCategoryButton = new Button('signup-edit-category')
 	.setLabel('Edit Category')

--- a/src/interactions/signups/settings/categories.ts
+++ b/src/interactions/signups/settings/categories.ts
@@ -1,0 +1,80 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+} from 'discord.js';
+import { Button } from '../../../builders/button';
+import { HydratedSignup } from '../../../db/signups';
+import { manageCategories, miscSettings, signupSettingsHome } from './general';
+
+export const editCategoryButton = new Button('signup-edit-category')
+	.setLabel('Edit Category')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const addCategoryButton = new Button('signup-add-category')
+	.setLabel('New Category')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const removeCategoryButton = new Button('signup-remove-category')
+	.setLabel('Remove Category')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export async function generalCategoriesEmbed(signup: HydratedSignup) {
+	const embed = new EmbedBuilder();
+	embed.setTitle(`Categories - ${signup.name}`);
+	embed.setColor('White');
+
+	embed.setDescription('Click the button below to add a new category');
+
+	const categories: string[] = [];
+	for (const category of signup.categories) {
+		let categoryStr = `> ${category.name}`;
+		if (category.limit)
+			categoryStr += ` [${category.users.length}/${category.limit}]`;
+		else categoryStr += ` [${category.users.length}]`;
+		categories.push(categoryStr);
+	}
+
+	if (categories.length > 0)
+		embed.addFields({
+			name: 'Categories',
+			value: `${categories.join('\n')}`,
+		});
+	else
+		embed.addFields({
+			name: 'Categories',
+			value: 'This signup has no categories',
+		});
+
+	const row = new ActionRowBuilder<ButtonBuilder>();
+	row.addComponents(signupSettingsHome.build());
+	row.addComponents(addCategoryButton.build());
+	if (categories.length > 0) {
+		row.addComponents(editCategoryButton.build());
+		row.addComponents(removeCategoryButton.build());
+	}
+
+	return {
+		embed,
+		row,
+	};
+}

--- a/src/interactions/signups/settings/categories/addUsers.ts
+++ b/src/interactions/signups/settings/categories/addUsers.ts
@@ -8,6 +8,7 @@ import { genEditCategoryMenu } from './editCategory';
 export const addUserMenu = new UserSelectMenu('add-user-to-category')
 	.setPlaceholder('Select users to add...')
 	.setMinValues(1)
+	.setMaxValues(25)
 	.setCustomId('add-user-to-category')
 	.onExecute(async (i, ctx) => {
 		if (!i.guild) {

--- a/src/interactions/signups/settings/categories/addUsers.ts
+++ b/src/interactions/signups/settings/categories/addUsers.ts
@@ -9,7 +9,6 @@ export const addUserMenu = new UserSelectMenu('add-user-to-category')
 	.setPlaceholder('Select users to add...')
 	.setMinValues(1)
 	.setMaxValues(25)
-	.setCustomId('add-user-to-category')
 	.onExecute(async (i, ctx) => {
 		if (!i.guild) {
 			throw new InteractionError(

--- a/src/interactions/signups/settings/categories/addUsers.ts
+++ b/src/interactions/signups/settings/categories/addUsers.ts
@@ -1,0 +1,112 @@
+import { UserSelectMenu } from '../../../../builders/userSelectMenu';
+import { addUserToCategory, getHydratedCategory } from '../../../../db/signups';
+import { getOrInsertUser } from '../../../../db/users';
+import { ErrorCode, InteractionError } from '../../../../utils/errors';
+import { onSignupUpdate } from '../../signupUpdateEvent';
+import { genEditCategoryMenu } from './editCategory';
+
+export const addUserMenu = new UserSelectMenu('add-user-to-category')
+	.setPlaceholder('Select users to add...')
+	.setMinValues(1)
+	.setCustomId('add-user-to-category')
+	.onExecute(async (i, ctx) => {
+		if (!i.guild) {
+			throw new InteractionError(
+				'Cannot use this command outside of a server'
+			);
+		}
+
+		if (!ctx)
+			throw new InteractionError(
+				'This button is invalid (no supplied category)'
+			);
+
+		const categoryId = parseInt(ctx);
+		if (isNaN(categoryId))
+			throw new InteractionError(
+				`Invalid context, expected an integer but got ${ctx}`
+			);
+
+		const category = await getHydratedCategory(categoryId);
+		if (!category)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Category not found',
+			});
+
+		const userIds = i.values;
+
+		if (
+			category.limit &&
+			userIds.length > category.limit - category.users.length
+		) {
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: `Cannot add more than ${category.limit} users to this category, you have ${category.users.length} already and are attempting to add ${userIds.length}`,
+			});
+		}
+
+		await i.deferUpdate();
+
+		if (!userIds || userIds.length <= 0)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must select at least one user',
+			});
+
+		const failedToAdd: string[] = [];
+
+		for (const userId of userIds) {
+			try {
+				const member = await i.guild.members.fetch(userId);
+				if (!member) {
+					failedToAdd.push(userId);
+					continue;
+				}
+				const user = await getOrInsertUser({
+					id: userId,
+					username: member.user.username,
+				});
+
+				if (!user) {
+					failedToAdd.push(userId);
+					continue;
+				}
+
+				const result = await addUserToCategory({
+					categoryId: category.id,
+					userId: user.id,
+				});
+
+				if (!result) failedToAdd.push(userId);
+			} catch (e) {
+				failedToAdd.push(userId);
+			}
+		}
+
+		if (failedToAdd.length > 0) {
+			await i.followUp({
+				content: `Failed to add ${failedToAdd
+					.map((u) => `<@${u}>`)
+					.join(', ')}`,
+				ephemeral: true,
+			});
+		}
+
+		const updatedCategory = await getHydratedCategory(categoryId);
+		if (!updatedCategory)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Category not found',
+			});
+
+		const { embed, rows } = genEditCategoryMenu(updatedCategory);
+		await i.editReply({
+			embeds: [embed],
+			components: [...rows],
+		});
+
+		await onSignupUpdate.publish({
+			signupId: category.signupId,
+		});
+	});

--- a/src/interactions/signups/settings/categories/changeLimit.ts
+++ b/src/interactions/signups/settings/categories/changeLimit.ts
@@ -1,0 +1,69 @@
+import { TextInputBuilder, TextInputStyle } from 'discord.js';
+import { Modal } from '../../../../builders/modal';
+import { ErrorCode, InteractionError } from '../../../../utils/errors';
+import { editCategory, getHydratedCategory } from '../../../../db/signups';
+import { genEditCategoryMenu } from './editCategory';
+import { onSignupUpdate } from '../../signupUpdateEvent';
+
+export const changeLimitModal = new Modal('change-category-limit')
+	.setCustomId('limit-category')
+	.setTitle('Change Limit')
+	.set(
+		new TextInputBuilder()
+			.setLabel('New Limit (type "blank" for no limit)')
+			.setStyle(TextInputStyle.Short)
+			.setRequired(true)
+			.setCustomId('limit')
+			.setMinLength(1)
+			.setMaxLength(5)
+	)
+	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This modal is invalid (no supplied category)'
+			);
+
+		const categoryId = parseInt(ctx);
+		if (isNaN(categoryId))
+			throw new InteractionError(
+				`Invalid context, expected an integer but got ${ctx}`
+			);
+
+		const newLimit = i.fields.getTextInputValue('limit');
+		if (!newLimit)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must provide a new name for the category',
+			});
+
+		let limit: undefined | number = undefined;
+		if (newLimit.toLowerCase() == 'blank') limit = undefined;
+		else if (!isNaN(parseInt(newLimit))) limit = parseInt(newLimit);
+		else {
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message:
+					'Invalid limit, must supply a number or a blank string',
+			});
+		}
+
+		const category = await editCategory(categoryId, {
+			limit: limit ?? null,
+		});
+		if (!category) throw new InteractionError('Invalid category');
+
+		await i.deferUpdate();
+
+		const hydratedCategory = await getHydratedCategory(categoryId);
+		if (!hydratedCategory) throw new InteractionError('Invalid category');
+
+		const { embed, rows } = genEditCategoryMenu(hydratedCategory);
+		await i.editReply({
+			embeds: [embed],
+			components: rows,
+		});
+
+		await onSignupUpdate.publish({
+			signupId: category.signupId,
+		});
+	});

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -1,0 +1,45 @@
+import { ChannelType, EmbedBuilder } from 'discord.js';
+import { TextSelectMenu } from '../../../../builders/textSelectMenu';
+import { InteractionError } from '../../../../utils/errors';
+import {
+	getHydratedSignupFromChannel,
+	HydratedCategory,
+} from '../../../../db/signups';
+
+export const editCategoryMenu = new TextSelectMenu('edit-category')
+	.setMinValues(1)
+	.setMaxValues(1)
+	.onExecute(async (i) => {
+		if (!i.guild)
+			throw new InteractionError(
+				'Cannot use this command outside of a server'
+			);
+		if (!i.channel || i.channel.type != ChannelType.GuildText)
+			throw new InteractionError(
+				'Cannot use this command outside of a text channel'
+			);
+
+		if (i.values.length < 1) throw new InteractionError('Invalid category');
+		const rawRequestedCategoryId = i.values.shift();
+		if (!rawRequestedCategoryId)
+			throw new InteractionError('Invalid category');
+
+		const categoryId = parseInt(rawRequestedCategoryId);
+		if (isNaN(categoryId)) throw new InteractionError('Invalid category');
+
+		const signup = await getHydratedSignupFromChannel(i.channelId);
+		if (!signup) throw new InteractionError('Failed to fetch signup');
+
+		const category = signup.categories.find((c) => c.id == categoryId);
+		if (!category) throw new InteractionError('Invalid category');
+
+		const { embed } = genEditCategoryMenu(category);
+		await i.update({ embeds: [embed] });
+	});
+
+export function genEditCategoryMenu(category: HydratedCategory) {
+	const embed = new EmbedBuilder();
+	embed.setTitle(`Edit Category - ${category.name}`);
+
+	return { embed };
+}

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -40,9 +40,11 @@ export const editCategoryMenu = new TextSelectMenu('edit-category')
 
 		const category = signup.categories.find((c) => c.id == categoryId);
 		if (!category) throw new InteractionError('Invalid category');
-
-		const { embed, row } = genEditCategoryMenu(category);
-		await i.update({ embeds: [embed], components: [row] });
+		const { embed, rows } = genEditCategoryMenu(category);
+		await i.update({
+			embeds: [embed],
+			components: [...rows],
+		});
 	});
 
 export function genEditCategoryMenu(category: HydratedCategory) {
@@ -64,17 +66,20 @@ export function genEditCategoryMenu(category: HydratedCategory) {
 		value: users.length > 0 ? `${users.join('\n')}` : '> None',
 	});
 
-	const row = new ActionRowBuilder<ButtonBuilder>();
-
-	row.addComponents(
-		addUserButton.build(),
-		removeUserButton.build(),
-		cullUserButton.build(),
-		renameCategoryButton.build(),
-		limitChangeButton.build()
-	);
-
-	return { embed, row };
+	return {
+		embed,
+		rows: [
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				addUserButton.build(),
+				removeUserButton.build(),
+				cullUserButton.build()
+			),
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				renameCategoryButton.build(),
+				limitChangeButton.build()
+			),
+		],
+	};
 }
 
 export const addUserButton = new Button('add-user-to-category')

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -4,6 +4,7 @@ import {
 	ButtonStyle,
 	ChannelType,
 	EmbedBuilder,
+	UserSelectMenuBuilder,
 } from 'discord.js';
 import { TextSelectMenu } from '../../../../builders/textSelectMenu';
 import { InteractionError } from '../../../../utils/errors';
@@ -17,6 +18,8 @@ import { signupSettingsHome } from '../general';
 import { renameCategoryModal } from './renameCategory';
 import { CustomId } from '../../../../utils/customId';
 import { changeLimitModal } from './changeLimit';
+import { addUserMenu } from './addUsers';
+import { UserSelectMenu } from '../../../../builders/userSelectMenu';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -90,11 +93,18 @@ export function genEditCategoryMenu(category: HydratedCategory) {
 export const addUserButton = new Button('add-user-to-category')
 	.setLabel('Add Users')
 	.setStyle(ButtonStyle.Secondary)
-	.onExecute(async (i) => {
-		await i.reply({
-			content: 'This feature is not yet implemented',
-			ephemeral: true,
-		});
+	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This button is invalid (no supplied category)'
+			);
+		const row = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(
+			addUserMenu.build(
+				new CustomId(addUserMenu.getCustomId(), ctx).getHydrated()
+			)
+		);
+
+		await i.update({ components: [row] });
 	});
 
 export const removeUserButton = new Button('remove-user-from-category')
@@ -131,6 +141,10 @@ export const limitChangeButton = new Button('change-category-limit')
 	.setLabel('Change Limit')
 	.setStyle(ButtonStyle.Secondary)
 	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This button is invalid (no supplied category)'
+			);
 		const modal = changeLimitModal.build(
 			new CustomId('change-category-limit', ctx).getHydrated()
 		);

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -13,6 +13,9 @@ import {
 } from '../../../../db/signups';
 import { cleanUsername } from '../../../../utils/usernames';
 import { Button } from '../../../../builders/button';
+import { signupSettingsHome } from '../general';
+import { renameCategoryModal } from './renameCategory';
+import { CustomId } from '../../../../utils/customId';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -70,13 +73,14 @@ export function genEditCategoryMenu(category: HydratedCategory) {
 		embed,
 		rows: [
 			new ActionRowBuilder<ButtonBuilder>().addComponents(
-				addUserButton.build(),
-				removeUserButton.build(),
-				cullUserButton.build()
+				signupSettingsHome.build(),
+				renameCategoryButton.buildWithContext(String(category.id)),
+				limitChangeButton.buildWithContext(String(category.id))
 			),
 			new ActionRowBuilder<ButtonBuilder>().addComponents(
-				renameCategoryButton.build(),
-				limitChangeButton.build()
+				addUserButton.buildWithContext(String(category.id)),
+				removeUserButton.buildWithContext(String(category.id)),
+				cullUserButton.buildWithContext(String(category.id))
 			),
 		],
 	};
@@ -113,17 +117,20 @@ export const cullUserButton = new Button('cull-user-from-category')
 	});
 
 export const renameCategoryButton = new Button('rename-category')
-	.setLabel('Rename Category')
+	.setLabel('Rename')
 	.setStyle(ButtonStyle.Secondary)
-	.onExecute(async (i) => {
-		await i.reply({
-			content: 'This feature is not yet implemented',
-			ephemeral: true,
-		});
+	.onExecute(async (i, ctx) => {
+		const modal = renameCategoryModal.build(
+			new CustomId('rename-category', ctx).getHydrated()
+		);
+
+		console.log(modal.data);
+
+		await i.showModal(modal);
 	});
 
 export const limitChangeButton = new Button('change-category-limit')
-	.setLabel('Change Category Limit')
+	.setLabel('Change Limit')
 	.setStyle(ButtonStyle.Secondary)
 	.onExecute(async (i) => {
 		await i.reply({

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -16,6 +16,7 @@ import { Button } from '../../../../builders/button';
 import { signupSettingsHome } from '../general';
 import { renameCategoryModal } from './renameCategory';
 import { CustomId } from '../../../../utils/customId';
+import { changeLimitModal } from './changeLimit';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -123,18 +124,15 @@ export const renameCategoryButton = new Button('rename-category')
 		const modal = renameCategoryModal.build(
 			new CustomId('rename-category', ctx).getHydrated()
 		);
-
-		console.log(modal.data);
-
 		await i.showModal(modal);
 	});
 
 export const limitChangeButton = new Button('change-category-limit')
 	.setLabel('Change Limit')
 	.setStyle(ButtonStyle.Secondary)
-	.onExecute(async (i) => {
-		await i.reply({
-			content: 'This feature is not yet implemented',
-			ephemeral: true,
-		});
+	.onExecute(async (i, ctx) => {
+		const modal = changeLimitModal.build(
+			new CustomId('change-category-limit', ctx).getHydrated()
+		);
+		await i.showModal(modal);
 	});

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -19,7 +19,7 @@ import { renameCategoryModal } from './renameCategory';
 import { CustomId } from '../../../../utils/customId';
 import { changeLimitModal } from './changeLimit';
 import { addUserMenu } from './addUsers';
-import { UserSelectMenu } from '../../../../builders/userSelectMenu';
+import { removeUserMenu } from './removeUsers';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -110,11 +110,18 @@ export const addUserButton = new Button('add-user-to-category')
 export const removeUserButton = new Button('remove-user-from-category')
 	.setLabel('Remove User')
 	.setStyle(ButtonStyle.Secondary)
-	.onExecute(async (i) => {
-		await i.reply({
-			content: 'This feature is not yet implemented',
-			ephemeral: true,
-		});
+	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This button is invalid (no supplied category)'
+			);
+
+		const row = new ActionRowBuilder<UserSelectMenuBuilder>().addComponents(
+			removeUserMenu.build(
+				new CustomId(removeUserMenu.getCustomId(), ctx).getHydrated()
+			)
+		);
+		await i.update({ components: [row] });
 	});
 
 export const cullUserButton = new Button('cull-user-from-category')

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -5,6 +5,7 @@ import {
 	getHydratedSignupFromChannel,
 	HydratedCategory,
 } from '../../../../db/signups';
+import { cleanUsername } from '../../../../utils/usernames';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -40,6 +41,21 @@ export const editCategoryMenu = new TextSelectMenu('edit-category')
 export function genEditCategoryMenu(category: HydratedCategory) {
 	const embed = new EmbedBuilder();
 	embed.setTitle(`Edit Category - ${category.name}`);
+
+	const users: string[] = [];
+	for (const user of category.users) {
+		users.push(cleanUsername(user.username));
+	}
+
+	let categoryTitle: string = '';
+	if (category.limit)
+		categoryTitle = `${category.name} [${users.length}/${category.limit}]`;
+	else categoryTitle = `${category.name} [${users.length}]`;
+
+	embed.addFields({
+		name: categoryTitle,
+		value: users.length > 0 ? `${users.join('\n')}` : '> None',
+	});
 
 	return { embed };
 }

--- a/src/interactions/signups/settings/categories/editCategory.ts
+++ b/src/interactions/signups/settings/categories/editCategory.ts
@@ -1,4 +1,10 @@
-import { ChannelType, EmbedBuilder } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ChannelType,
+	EmbedBuilder,
+} from 'discord.js';
 import { TextSelectMenu } from '../../../../builders/textSelectMenu';
 import { InteractionError } from '../../../../utils/errors';
 import {
@@ -6,6 +12,7 @@ import {
 	HydratedCategory,
 } from '../../../../db/signups';
 import { cleanUsername } from '../../../../utils/usernames';
+import { Button } from '../../../../builders/button';
 
 export const editCategoryMenu = new TextSelectMenu('edit-category')
 	.setMinValues(1)
@@ -34,8 +41,8 @@ export const editCategoryMenu = new TextSelectMenu('edit-category')
 		const category = signup.categories.find((c) => c.id == categoryId);
 		if (!category) throw new InteractionError('Invalid category');
 
-		const { embed } = genEditCategoryMenu(category);
-		await i.update({ embeds: [embed] });
+		const { embed, row } = genEditCategoryMenu(category);
+		await i.update({ embeds: [embed], components: [row] });
 	});
 
 export function genEditCategoryMenu(category: HydratedCategory) {
@@ -57,5 +64,65 @@ export function genEditCategoryMenu(category: HydratedCategory) {
 		value: users.length > 0 ? `${users.join('\n')}` : '> None',
 	});
 
-	return { embed };
+	const row = new ActionRowBuilder<ButtonBuilder>();
+
+	row.addComponents(
+		addUserButton.build(),
+		removeUserButton.build(),
+		cullUserButton.build(),
+		renameCategoryButton.build(),
+		limitChangeButton.build()
+	);
+
+	return { embed, row };
 }
+
+export const addUserButton = new Button('add-user-to-category')
+	.setLabel('Add Users')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const removeUserButton = new Button('remove-user-from-category')
+	.setLabel('Remove User')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const cullUserButton = new Button('cull-user-from-category')
+	.setLabel('Cull Users')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const renameCategoryButton = new Button('rename-category')
+	.setLabel('Rename Category')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const limitChangeButton = new Button('change-category-limit')
+	.setLabel('Change Category Limit')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});

--- a/src/interactions/signups/settings/categories/removeUsers.ts
+++ b/src/interactions/signups/settings/categories/removeUsers.ts
@@ -1,0 +1,83 @@
+import { UserSelectMenu } from '../../../../builders/userSelectMenu';
+import {
+	getHydratedCategory,
+	removeUserFromCategory,
+} from '../../../../db/signups';
+import { ErrorCode, InteractionError } from '../../../../utils/errors';
+import { onSignupUpdate } from '../../signupUpdateEvent';
+import { genEditCategoryMenu } from './editCategory';
+
+export const removeUserMenu = new UserSelectMenu('remove-user-from-category')
+	.setPlaceholder('Select users to remove...')
+	.setMinValues(1)
+	.setMaxValues(25)
+	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This button is invalid (no supplied category)'
+			);
+
+		const categoryId = parseInt(ctx);
+		if (isNaN(categoryId))
+			throw new InteractionError(
+				`Invalid context, expected an integer but got ${ctx}`
+			);
+
+		const category = await getHydratedCategory(categoryId);
+		if (!category)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Category not found',
+			});
+
+		const userIds = i.values;
+		await i.deferUpdate();
+
+		if (!userIds || userIds.length <= 0)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must select at least one user',
+			});
+
+		const failed: string[] = [];
+
+		for (const userId of userIds) {
+			try {
+				const result = await removeUserFromCategory(
+					userId,
+					i.channelId,
+					category.name
+				);
+
+				if (!result) failed.push(userId);
+			} catch (e) {
+				failed.push(userId);
+			}
+		}
+
+		if (failed.length > 0) {
+			await i.followUp({
+				content: `Failed to remove ${failed
+					.map((u) => `<@${u}>`)
+					.join(', ')}`,
+				ephemeral: true,
+			});
+		}
+
+		const updatedCategory = await getHydratedCategory(categoryId);
+		if (!updatedCategory)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Category not found',
+			});
+
+		const { embed, rows } = genEditCategoryMenu(updatedCategory);
+		await i.editReply({
+			embeds: [embed],
+			components: [...rows],
+		});
+
+		await onSignupUpdate.publish({
+			signupId: category.signupId,
+		});
+	});

--- a/src/interactions/signups/settings/categories/renameCategory.ts
+++ b/src/interactions/signups/settings/categories/renameCategory.ts
@@ -1,0 +1,73 @@
+import { TextInputBuilder, TextInputStyle } from 'discord.js';
+import { Modal } from '../../../../builders/modal';
+import { ErrorCode, InteractionError } from '../../../../utils/errors';
+import { editCategory, getHydratedCategory } from '../../../../db/signups';
+import { genEditCategoryMenu } from './editCategory';
+import { onSignupUpdate } from '../../signupUpdateEvent';
+
+export const renameCategoryModal = new Modal('rename-category')
+	.setCustomId('rename-category')
+	.setTitle('Rename Category')
+	.set(
+		new TextInputBuilder()
+			.setLabel('New Title')
+			.setStyle(TextInputStyle.Short)
+			.setRequired(true)
+			.setCustomId('title')
+			.setMinLength(1)
+			.setMaxLength(32),
+		new TextInputBuilder()
+			.setLabel('Button Label')
+			.setStyle(TextInputStyle.Short)
+			.setRequired(false)
+			.setCustomId('button')
+			.setMinLength(1)
+			.setMaxLength(32)
+	)
+	.onExecute(async (i, ctx) => {
+		if (!ctx)
+			throw new InteractionError(
+				'This modal is invalid (no supplied category)'
+			);
+
+		const categoryId = parseInt(ctx);
+		if (isNaN(categoryId))
+			throw new InteractionError(
+				`Invalid context, expected an integer but got ${ctx}`
+			);
+
+		const newTitle = i.fields.getTextInputValue('title');
+		if (!newTitle)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must provide a new name for the category',
+			});
+
+		const newButton = i.fields.getTextInputValue('button');
+		if (!newButton)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must provide a new button name for the category',
+			});
+
+		const category = await editCategory(categoryId, {
+			name: newTitle,
+			buttonName: newButton,
+		});
+		if (!category) throw new InteractionError('Invalid category');
+
+		await i.deferUpdate();
+
+		const hydratedCategory = await getHydratedCategory(categoryId);
+		if (!hydratedCategory) throw new InteractionError('Invalid category');
+
+		const { embed, rows } = genEditCategoryMenu(hydratedCategory);
+		await i.editReply({
+			embeds: [embed],
+			components: rows,
+		});
+
+		await onSignupUpdate.publish({
+			signupId: category.signupId,
+		});
+	});

--- a/src/interactions/signups/settings/changeTitle.ts
+++ b/src/interactions/signups/settings/changeTitle.ts
@@ -1,0 +1,55 @@
+import { ActionRowBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
+import { Modal } from '../../../builders/modal';
+import { ErrorCode, InteractionError } from '../../../utils/errors';
+import { getSignupByChannel, updateSignupName } from '../../../db/signups';
+import { onSignupUpdate } from '../signupUpdateEvent';
+
+export const changeSignupTitle = new Modal('change-signup-title')
+	.setCustomId('change-signup-title')
+	.setTitle('Change Signup Title')
+	.addComponents(
+		new ActionRowBuilder<TextInputBuilder>().addComponents(
+			new TextInputBuilder()
+				.setLabel('New Title')
+				.setStyle(TextInputStyle.Short)
+				.setRequired(true)
+				.setCustomId('title')
+				.setMinLength(1)
+				.setMaxLength(256)
+		)
+	)
+	.onExecute(async (i) => {
+		if (!i.channel)
+			throw new InteractionError({
+				status: ErrorCode.NotPermitted,
+				message: 'This modal can only be used in a channel',
+			});
+
+		await i.deferReply({ ephemeral: true });
+
+		const newName = i.fields.getTextInputValue('title');
+		if (!newName)
+			throw new InteractionError({
+				status: ErrorCode.BadRequest,
+				message: 'You must provide a new name for the signup',
+			});
+
+		const signup = await getSignupByChannel(i.channel.id);
+		if (!signup)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Failed to find signup',
+			});
+
+		await updateSignupName(signup.id, newName);
+
+		const msg = await i.channel.messages.fetch(signup.messageId);
+		if (!msg) throw new InteractionError('Failed to fetch message');
+
+		await onSignupUpdate.publish({
+			message: msg,
+			messageId: signup.messageId,
+		});
+
+		await i.deleteReply();
+	});

--- a/src/interactions/signups/settings/general.ts
+++ b/src/interactions/signups/settings/general.ts
@@ -1,0 +1,93 @@
+import {
+	EmbedBuilder,
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+} from 'discord.js';
+import {
+	getHydratedSignupFromChannel,
+	HydratedSignup,
+} from '../../../db/signups';
+import { Button } from '../../../builders/button';
+import { generalCategoriesEmbed } from './categories';
+import { InteractionError, ErrorCode } from '../../../utils/errors';
+import { generalMiscEmbed } from './misc';
+
+export const manageCategories = new Button('signup-manage-categories')
+	.setLabel('Categories')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		if (!i.channelId)
+			throw new InteractionError({
+				status: ErrorCode.NotPermitted,
+				message: 'This button can only be used in a channel',
+			});
+		const signup = await getHydratedSignupFromChannel(i.channelId);
+		if (!signup)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Failed to find signup',
+			});
+
+		const { embed, row } = await generalCategoriesEmbed(signup);
+		await i.update({ embeds: [embed], components: [row] });
+	});
+
+export const miscSettings = new Button('signup-manage-misc')
+	.setLabel('Misc Settings')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		if (!i.channelId)
+			throw new InteractionError({
+				status: ErrorCode.NotPermitted,
+				message: 'This button can only be used in a channel',
+			});
+		const signup = await getHydratedSignupFromChannel(i.channelId);
+		if (!signup)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Failed to find signup',
+			});
+
+		const { embed, row } = await generalMiscEmbed(signup);
+		await i.update({ embeds: [embed], components: [row] });
+	});
+
+export const signupSettingsHome = new Button('signup-settings-home')
+	.setLabel('Home')
+	.setStyle(ButtonStyle.Primary)
+	.onExecute(async (i) => {
+		if (!i.channelId)
+			throw new InteractionError({
+				status: ErrorCode.NotPermitted,
+				message: 'This button can only be used in a channel',
+			});
+
+		const signup = await getHydratedSignupFromChannel(i.channelId);
+		if (!signup)
+			throw new InteractionError({
+				status: ErrorCode.NotFound,
+				message: 'Failed to find signup',
+			});
+
+		const { embed, row } = await generalSettingsEmbed(signup);
+		await i.update({ embeds: [embed], components: [row] });
+	});
+
+export async function generalSettingsEmbed(signup: HydratedSignup) {
+	const embed = new EmbedBuilder();
+	embed.setTitle(signup.name);
+	embed.setColor('White');
+	embed.setDescription(
+		"Click the buttons below to edit the signup's settings"
+	);
+
+	const row = new ActionRowBuilder<ButtonBuilder>();
+	row.addComponents(manageCategories.build());
+	row.addComponents(miscSettings.build());
+
+	return {
+		embed,
+		row,
+	};
+}

--- a/src/interactions/signups/settings/general.ts
+++ b/src/interactions/signups/settings/general.ts
@@ -13,6 +13,15 @@ import { generalCategoriesEmbed } from './categories';
 import { InteractionError, ErrorCode } from '../../../utils/errors';
 import { generalMiscEmbed } from './misc';
 
+export const helpCategoryButton = new Button('signup-help')
+	.setStyle(ButtonStyle.Secondary)
+	.setEmoji('❔')
+	.onExecute(async (i) => {
+		const helpStr =
+			'This is a placeholder for help\nPlease contact Mel (or another member of staff) if you have any questions';
+		await i.reply({ ephemeral: true, content: `\`\`\`${helpStr}\`\`\`` });
+	});
+
 export const manageCategories = new Button('signup-manage-categories')
 	.setLabel('Categories')
 	.setStyle(ButtonStyle.Secondary)
@@ -85,6 +94,7 @@ export async function generalSettingsEmbed(signup: HydratedSignup) {
 	const row = new ActionRowBuilder<ButtonBuilder>();
 	row.addComponents(manageCategories.build());
 	row.addComponents(miscSettings.build());
+	row.addComponents(helpCategoryButton.build());
 
 	return {
 		embed,

--- a/src/interactions/signups/settings/misc.ts
+++ b/src/interactions/signups/settings/misc.ts
@@ -1,0 +1,53 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+} from 'discord.js';
+import { Button } from '../../../builders/button';
+import { HydratedSignup } from '../../../db/signups';
+import { manageCategories, miscSettings, signupSettingsHome } from './general';
+
+export const editSignupName = new Button('signup-edit-title')
+	.setLabel('Change Name')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export const toggleAnonymity = new Button('signup-edit-anonymity')
+	.setLabel('Toggle Anonymity')
+	.setStyle(ButtonStyle.Secondary)
+	.onExecute(async (i) => {
+		await i.reply({
+			content: 'This feature is not yet implemented',
+			ephemeral: true,
+		});
+	});
+
+export async function generalMiscEmbed(signup: HydratedSignup) {
+	const embed = new EmbedBuilder();
+	embed.setTitle(`Misc - ${signup.name}`);
+	embed.setColor('White');
+
+	embed.setDescription('Manage assorted misc settings with this signup');
+
+	embed.addFields({
+		name: 'Anonymity',
+		value: `> ${signup.isAnonymous ? 'Enabled' : 'Disabled'}`,
+		inline: true,
+	});
+
+	const row = new ActionRowBuilder<ButtonBuilder>();
+	row.addComponents(signupSettingsHome.build());
+	row.addComponents(editSignupName.build());
+	row.addComponents(toggleAnonymity.build());
+
+	return {
+		embed,
+		row,
+	};
+}

--- a/src/interactions/signups/settings/misc.ts
+++ b/src/interactions/signups/settings/misc.ts
@@ -13,15 +13,13 @@ import {
 import { signupSettingsHome } from './general';
 import { InteractionError, ErrorCode } from '../../../utils/errors';
 import { onSignupUpdate } from '../signupUpdateEvent';
+import { changeSignupTitle } from './changeTitle';
 
 export const editSignupName = new Button('signup-edit-title')
 	.setLabel('Change Name')
 	.setStyle(ButtonStyle.Secondary)
 	.onExecute(async (i) => {
-		await i.reply({
-			content: 'This feature is not yet implemented',
-			ephemeral: true,
-		});
+		await i.showModal(changeSignupTitle);
 	});
 
 export const toggleAnonymity = new Button('signup-edit-anonymity')

--- a/src/interactions/signups/signupUpdateEvent.ts
+++ b/src/interactions/signups/signupUpdateEvent.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, Interaction, Message } from 'discord.js';
+import { Interaction, Message } from 'discord.js';
 import { getHydratedSignup } from '../../db/signups';
 import { formatSignupEmbed, formatSignupComponents } from '../../views/signup';
 import { Event } from '../../builders/event';

--- a/src/interactions/signups/signupUpdateEvent.ts
+++ b/src/interactions/signups/signupUpdateEvent.ts
@@ -1,34 +1,62 @@
-import { Interaction, Message } from 'discord.js';
+import { ChannelType, Interaction, Message } from 'discord.js';
 import { getHydratedSignup } from '../../db/signups';
 import { formatSignupEmbed, formatSignupComponents } from '../../views/signup';
 import { Event } from '../../builders/event';
+import { client } from '../../controllers/discord';
 export type SignupUpdateEvent =
 	| { messageId: string; i: Interaction }
-	| { messageId: string; message: Message };
+	| { messageId: string; message: Message }
+	| { signupId: number };
 
 export const onSignupUpdate = new Event<SignupUpdateEvent>().subscribe(
 	async (data) => {
-		const hydratedSignup = await getHydratedSignup(data.messageId);
-		if (!hydratedSignup) return;
+		if ('messageId' in data) {
+			const hydratedSignup = await getHydratedSignup({
+				messageId: data.messageId,
+			});
+			if (!hydratedSignup) return;
 
-		const embed = formatSignupEmbed(hydratedSignup);
-		const components = formatSignupComponents(hydratedSignup);
+			const embed = formatSignupEmbed(hydratedSignup);
+			const components = formatSignupComponents(hydratedSignup);
 
-		if ('i' in data) {
-			if (data.i.isButton())
-				return await data.i.update({
-					embeds: [embed],
-					components: [components],
-				});
-			else if (data.i.isChatInputCommand()) {
-				return await data.i.editReply({
-					embeds: [embed],
-					components: [components],
-				});
+			if ('i' in data) {
+				if (data.i.isButton())
+					return await data.i.update({
+						embeds: [embed],
+						components: [components],
+					});
+				else if (data.i.isChatInputCommand()) {
+					return await data.i.editReply({
+						embeds: [embed],
+						components: [components],
+					});
+				}
+				return;
 			}
-			return;
-		}
 
-		await data.message.edit({ embeds: [embed], components: [components] });
+			await data.message.edit({
+				embeds: [embed],
+				components: [components],
+			});
+		} else {
+			const signup = await getHydratedSignup({
+				signupId: data.signupId,
+			});
+			if (!signup) return;
+
+			const guild = await client.guilds.fetch(signup.guildId);
+			if (!guild) return;
+
+			const channel = await guild.channels.fetch(signup.channelId);
+			if (!channel || channel.type != ChannelType.GuildText) return;
+
+			const msg = await channel.messages.fetch(signup.messageId);
+			if (!msg) return;
+
+			const embed = formatSignupEmbed(signup);
+			const components = formatSignupComponents(signup);
+
+			await msg.edit({ embeds: [embed], components: [components] });
+		}
 	}
 );

--- a/src/utils/customId.ts
+++ b/src/utils/customId.ts
@@ -1,23 +1,47 @@
 export const CUSTOM_ID_SEPERATOR = ':';
 
-export function verifyCustomId(custom_id: string) {
-	return !custom_id.includes(CUSTOM_ID_SEPERATOR);
-}
+export class CustomId {
+	private customId: string;
+	private context: string | undefined;
+	constructor(customId: string, context?: string) {
+		if (!CustomId.verifyRaw(customId))
+			throw new Error(
+				`Custom id ${customId} is not in the correct format.`
+			);
 
-export type ParsedCustomID = {
-	custom_id: string;
-	context?: string;
-};
-export function parseCustomId(custom_id: string): ParsedCustomID {
-	const split = custom_id.split(CUSTOM_ID_SEPERATOR);
-	const parsed_custom_id = split.shift() ?? custom_id;
-	return {
-		custom_id: parsed_custom_id,
-		context: split.join(CUSTOM_ID_SEPERATOR),
-	};
-}
+		this.customId = customId;
+		this.context = context;
+	}
 
-export function createCustomId(custom_id: string, context?: string) {
-	if (!context) return custom_id;
-	return `${custom_id}${CUSTOM_ID_SEPERATOR}${context}`;
+	getHydrated() {
+		if (!this.context) return this.customId;
+		return `${this.customId}${CUSTOM_ID_SEPERATOR}${this.context}`;
+	}
+
+	getId() {
+		return this.customId;
+	}
+
+	getContext() {
+		return this.context;
+	}
+
+	setCustomId(customId: string) {
+		this.customId = customId;
+	}
+
+	setContext(context: string) {
+		this.context = context;
+	}
+
+	static parseString(customId: string) {
+		const split = customId.split(CUSTOM_ID_SEPERATOR);
+		const parsed_custom_id = split.shift() ?? customId;
+
+		return new CustomId(parsed_custom_id, split.join(CUSTOM_ID_SEPERATOR));
+	}
+
+	static verifyRaw(customId: string) {
+		return !customId.includes(CUSTOM_ID_SEPERATOR);
+	}
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,6 +6,7 @@ export enum ErrorCode {
 	Unknown = 'UNKNOWN',
 	NotPermitted = 'NOT_PERMITTED',
 	NotImplemented = 'NOT_IMPLEMENTED',
+	NotFound = 'NOT_FOUND',
 }
 
 export type StatusMessage = {
@@ -19,6 +20,7 @@ export const defaultStatusMessages: Record<ErrorCode, string> = {
 	[ErrorCode.NotPermitted]:
 		'You do not have the required permissions to do this',
 	[ErrorCode.NotImplemented]: 'This feature has not been implemented yet',
+	[ErrorCode.NotFound]: 'The requested resource was not found',
 };
 
 const embedErrorJokeNames: string[] = [

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,6 +7,7 @@ export enum ErrorCode {
 	NotPermitted = 'NOT_PERMITTED',
 	NotImplemented = 'NOT_IMPLEMENTED',
 	NotFound = 'NOT_FOUND',
+	BadRequest = 'BAD_REQUEST',
 }
 
 export type StatusMessage = {
@@ -21,6 +22,7 @@ export const defaultStatusMessages: Record<ErrorCode, string> = {
 		'You do not have the required permissions to do this',
 	[ErrorCode.NotImplemented]: 'This feature has not been implemented yet',
 	[ErrorCode.NotFound]: 'The requested resource was not found',
+	[ErrorCode.BadRequest]: 'The request was invalid',
 };
 
 const embedErrorJokeNames: string[] = [

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,0 +1,37 @@
+import { EmbedBuilder, WebhookClient } from 'discord.js';
+import config from '../config';
+
+export enum LogType {
+	JOIN,
+	LEAVE,
+}
+interface LogOptions {
+	user: string;
+	channelId: string;
+	categoryName?: string;
+	type: LogType;
+}
+export async function logSignup(options: LogOptions) {
+	if (!config.TMP_SIGNUP_LOG_WEBHOOK) return;
+
+	const webhook = new WebhookClient({
+		url: config.TMP_SIGNUP_LOG_WEBHOOK,
+	});
+
+	const embed = new EmbedBuilder();
+	embed.setTitle('Signup Log');
+	embed.setDescription(
+		`**${options.user}** ${
+			options.type == LogType.JOIN ? 'joined' : 'left'
+		}${options.categoryName ? ' ' + options.categoryName : ''}`
+	);
+	embed.addFields({ name: 'Channel', value: `<#${options.channelId}>` });
+	embed.setTimestamp(new Date());
+
+	if (options.type == LogType.JOIN) embed.setColor('Green');
+	else embed.setColor('Red');
+
+	webhook.send({
+		embeds: [embed],
+	});
+}

--- a/src/utils/usernames.ts
+++ b/src/utils/usernames.ts
@@ -1,0 +1,22 @@
+export function cleanUsername(username: string) {
+	const illegal_chars = [
+		'*',
+		'_',
+		'~',
+		'`',
+		'|',
+		'>',
+		'[',
+		']',
+		'(',
+		')',
+		':',
+	];
+
+	const regex = new RegExp(
+		`([${illegal_chars.map((char) => `\\${char}`).join('')}])`,
+		'g'
+	);
+
+	return username.replace(regex, '\\$1');
+}

--- a/src/views/signup.ts
+++ b/src/views/signup.ts
@@ -8,10 +8,11 @@ import {
 	ButtonStyle,
 } from 'discord.js';
 import { HydratedSignup } from '../db/signups';
-import { createCustomId } from '../utils/customId';
 import { leaveCategoryBtn } from '../interactions/signups/buttons/categoryLeave';
 import settings from '../interactions/signups/buttons/settings';
 import { cleanUsername } from '../utils/usernames';
+import { CustomId } from '../utils/customId';
+import { custom } from 'zod';
 
 export function formatSignupEmbed(signup: HydratedSignup) {
 	const embed = new EmbedBuilder();
@@ -72,8 +73,9 @@ export function formatSignupComponents(signup: HydratedSignup) {
 	signup.categories.forEach((category) => {
 		if (category.isHoisted) return;
 		const btn = new ButtonBuilder();
-		const customId = createCustomId('signup-join', category.id.toString());
-		btn.setCustomId(customId);
+
+		const customId = new CustomId('signup-join', category.id.toString());
+		btn.setCustomId(customId.getHydrated());
 
 		let label = category.buttonName ?? category.name;
 		if (!category.buttonName && label.charAt(label.length - 1) === 's')

--- a/src/views/signup.ts
+++ b/src/views/signup.ts
@@ -11,6 +11,7 @@ import { HydratedSignup } from '../db/signups';
 import { createCustomId } from '../utils/customId';
 import { leaveCategoryBtn } from '../interactions/signups/buttons/categoryLeave';
 import settings from '../interactions/signups/buttons/settings';
+import { cleanUsername } from '../utils/usernames';
 
 export function formatSignupEmbed(signup: HydratedSignup) {
 	const embed = new EmbedBuilder();
@@ -31,27 +32,7 @@ export function formatSignupEmbed(signup: HydratedSignup) {
 	for (const category of signup.categories) {
 		const users_str: string[] = [];
 		for (const user of category.users) {
-			const illegal_chars = [
-				'*',
-				'_',
-				'~',
-				'`',
-				'|',
-				'>',
-				'[',
-				']',
-				'(',
-				')',
-				':',
-			];
-
-			const regex = new RegExp(
-				`([${illegal_chars.map((char) => `\\${char}`).join('')}])`,
-				'g'
-			);
-
-			const username = user.username.replace(regex, '\\$1');
-
+			const username = cleanUsername(user.username);
 			if (signup.isAnonymous && !category.isHoisted)
 				users_str.push('> Anonymous User');
 			else users_str.push(`> ${username}`);

--- a/src/views/signup.ts
+++ b/src/views/signup.ts
@@ -83,6 +83,10 @@ export function formatSignupComponents(signup: HydratedSignup) {
 		btn.setStyle(
 			category.isFocused ? ButtonStyle.Primary : ButtonStyle.Secondary
 		);
+
+		if (category.limit)
+			btn.setDisabled(category.users.length >= category.limit);
+
 		buttons.push(btn);
 	});
 

--- a/src/views/signup.ts
+++ b/src/views/signup.ts
@@ -12,7 +12,6 @@ import { leaveCategoryBtn } from '../interactions/signups/buttons/categoryLeave'
 import settings from '../interactions/signups/buttons/settings';
 import { cleanUsername } from '../utils/usernames';
 import { CustomId } from '../utils/customId';
-import { custom } from 'zod';
 
 export function formatSignupEmbed(signup: HydratedSignup) {
 	const embed = new EmbedBuilder();
@@ -31,6 +30,10 @@ export function formatSignupEmbed(signup: HydratedSignup) {
 	signup.categories.sort((a, b) => a.id - b.id);
 
 	for (const category of signup.categories) {
+		category.users.sort(
+			(a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+		);
+
 		const users_str: string[] = [];
 		for (const user of category.users) {
 			const username = cleanUsername(user.username);


### PR DESCRIPTION
Added the cog menu back from the old version.
- Creating categories
- Deleting categories
- Updating categories
  - Rename
  - Change limit
  - Add users
  - Remove users
  - Cull users that left the server (as they cannot be fetched via a user select menu)
- Toggle anonymity
- Change name of signups
- Signup logging using webhooks